### PR TITLE
1.3.2 proposal.

### DIFF
--- a/BGSpawn/BGSpawn.tp2
+++ b/BGSpawn/BGSpawn.tp2
@@ -2,7 +2,7 @@ BACKUP ~weidu_external/backup/BGSpawn~
 
 SUPPORT ~http://www.shsforums.net/topic/39639-release-bgspawn-version-111/~ //AUTHOR ~Melkor Morgoth75~
 
-VERSION ~1.3.1~
+VERSION ~1.3.2~
 
 README ~%MOD_FOLDER%/docs/BGSpawnReadme.doc~
 

--- a/BGSpawn/BGSpawn.tp2
+++ b/BGSpawn/BGSpawn.tp2
@@ -148,6 +148,7 @@ ALWAYS
     OUTER_SPRINT "spawnRem" 0
 
     ACTION_IF GAME_IS ~bgt~ BEGIN
+        // areas
         OUTER_SPRINT "Undercity" "AR7223"
         OUTER_SPRINT "WSewers" "AR7324"
         OUTER_SPRINT "CentralSewers" "AR7325"
@@ -208,9 +209,15 @@ ALWAYS
         OUTER_SPRINT "Encounter_Forest1" "AR5300"
         OUTER_SPRINT "Encounter_Forest2" "AR5301"
         OUTER_SPRINT "Encounter_Road" "AR5400"
+        // creature files
+        OUTER_SPRINT "Basilisk" "BGBASILL"
+        // OUTER_SPRINT "Ghast" "BGGHAST" not-in-use
+        OUTER_SPRINT "Wolf" "BGWOLF"
+        // OUTER_SPRINT "GreaterWolfwere" "BGWOWEGR" not-in-use
 
 
     END ELSE ACTION_IF GAME_IS ~eet~ BEGIN
+        // areas
         OUTER_SPRINT "Undercity" "BG0123"
         OUTER_SPRINT "WSewers" "BG0224"
         OUTER_SPRINT "CentralSewers" "BG0225"
@@ -271,6 +278,11 @@ ALWAYS
         OUTER_SPRINT "Encounter_Forest1" "BG6000"
         OUTER_SPRINT "Encounter_Forest2" "BG6001"
         OUTER_SPRINT "Encounter_Road" "BG6100"
+        // creature files
+        OUTER_SPRINT "Basilisk" "BASILL"
+        // OUTER_SPRINT "Ghast" "GHAST" not-in-use
+        OUTER_SPRINT "Wolf" "WOLF"
+        // OUTER_SPRINT "GreaterWolfwere" "WOLFWEGR" not-in-use
     END
 
     ACTION_DEFINE_ASSOCIATIVE_ARRAY file_names BEGIN
@@ -617,18 +629,31 @@ BEGIN @1105 DESIGNATED 5000 LABEL "BGSpawn-RandomEncounters"
         COPY ~%MOD_FOLDER%/are_bgt/AR5101.ARE~ ~override~
         COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/are_bgt~
     END ELSE ACTION_IF GAME_IS ~eet~ BEGIN
-        COPY ~%MOD_FOLDER%/are_eet/BG5600.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5601.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5700.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5701.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5800.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5801.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5900.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG5901.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG6000.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG6001.ARE~ ~override~
-        COPY ~%MOD_FOLDER%/are_eet/BG6100.ARE~ ~override~
-        COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/are_eet~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5600.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5601.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5700.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5701.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5800.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5801.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5900.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG5901.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG6000.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG6001.ARE~ ~override~
+        // COPY ~%MOD_FOLDER%/are_eet/BG6100.ARE~ ~override~
+        // COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/are_eet~
+        
+        // need to EXTEND_BOTTOM here, because COMPILE overwrite Dorn's fixed encounter (the scripts exist in the basegame already)
+        EXTEND_BOTTOM ~BG5600.BCS~ ~%MOD_FOLDER%/are_eet/BG5600.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5601.BCS~ ~%MOD_FOLDER%/are_eet/BG5601.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5700.BCS~ ~%MOD_FOLDER%/are_eet/BG5700.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5701.BCS~ ~%MOD_FOLDER%/are_eet/BG5701.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5800.BCS~ ~%MOD_FOLDER%/are_eet/BG5800.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5801.BCS~ ~%MOD_FOLDER%/are_eet/BG5801.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5900.BCS~ ~%MOD_FOLDER%/are_eet/BG5900.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG5901.BCS~ ~%MOD_FOLDER%/are_eet/BG5901.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG6000.BCS~ ~%MOD_FOLDER%/are_eet/BG6000.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG6001.BCS~ ~%MOD_FOLDER%/are_eet/BG6001.baf~ EVALUATE_BUFFER
+        EXTEND_BOTTOM ~BG6100.BCS~ ~%MOD_FOLDER%/are_eet/BG6100.baf~ EVALUATE_BUFFER
     END
     COPY ~%MOD_FOLDER%/cre/sbaloch.CRE~ ~override~
         SAY 0x8 @1307

--- a/BGSpawn/Changelog.md
+++ b/BGSpawn/Changelog.md
@@ -1,3 +1,11 @@
+# 1.3.2: Graion Dilach
+- Fix: Substitute the remaining few BGT area names on EET.
+- Fix: Don't use BGT creature names where EET and BGT names differ.
+- Fix: Random Encounter component no longer breaks Dorn's fixed encounter.
+
+# 1.3.1: Graion Dilach
+- Fix: Move area list definition to the ALWAYS block to ensure substitution when a spawnprobability component si installed.
+
 # 1.3.0: AL|EN
 - replaced ACTION_READLN with SUBCOMPONENT to not halt installation
 - added DESIGNATED numbers

--- a/BGSpawn/are_eet/BG5600.baf
+++ b/BGSpawn/are_eet/BG5600.baf
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -1490,7 +1490,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -1581,7 +1581,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -1688,7 +1688,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -1813,7 +1813,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -1979,7 +1979,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2080,7 +2080,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2190,7 +2190,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2275,7 +2275,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2389,7 +2389,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2510,7 +2510,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2629,12 +2629,12 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -2699,7 +2699,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -2785,7 +2785,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -2859,12 +2859,12 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -2945,18 +2945,18 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -3081,18 +3081,18 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -3202,14 +3202,14 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -5860,7 +5860,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -6007,7 +6007,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -6172,7 +6172,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -6366,7 +6366,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -6567,7 +6567,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -6882,7 +6882,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
 END
 
@@ -6988,7 +6988,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -7131,7 +7131,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -7314,7 +7314,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -7561,7 +7561,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -7835,7 +7835,7 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
@@ -8179,12 +8179,12 @@ THEN
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[566.234],0)  // Lesser Basilisk
     SetGlobalTimer("4700566234","%Encounter_Plains1%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset566234","%Encounter_Plains1%",1)

--- a/BGSpawn/are_eet/BG5601.baf
+++ b/BGSpawn/are_eet/BG5601.baf
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -1490,7 +1490,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -1581,7 +1581,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -1688,7 +1688,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -1813,7 +1813,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -1979,7 +1979,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2080,7 +2080,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2190,7 +2190,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2275,7 +2275,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2389,7 +2389,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2510,7 +2510,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2629,12 +2629,12 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -2699,7 +2699,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -2785,7 +2785,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -2859,12 +2859,12 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -2945,18 +2945,18 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -3081,18 +3081,18 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -3202,14 +3202,14 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -5860,7 +5860,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -6007,7 +6007,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -6172,7 +6172,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -6366,7 +6366,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -6567,7 +6567,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -6882,7 +6882,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
 END
 
@@ -6988,7 +6988,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -7131,7 +7131,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -7314,7 +7314,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -7561,7 +7561,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -7835,7 +7835,7 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
@@ -8179,12 +8179,12 @@ THEN
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
+    CreateCreature("BASILL",[770.301],0)  // Lesser Basilisk
     SetGlobalTimer("4701770301","%Encounter_Plains2%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset770301","%Encounter_Plains2%",1)

--- a/BGSpawn/are_eet/BG5800.baf
+++ b/BGSpawn/are_eet/BG5800.baf
@@ -6116,7 +6116,6 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset1196106","%Encounter_Cliff1%",1)
-    CreateCreature("BGWOLF",[1196.106],0)  // ~Wolf~
+    CreateCreature("WOLF",[1196.106],0)  // ~Wolf~
     SetGlobalTimer("49001196106","%Encounter_Cliff1%",2400)
 END
-

--- a/BGSpawn/are_eet/BG5801.baf
+++ b/BGSpawn/are_eet/BG5801.baf
@@ -6116,7 +6116,6 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset990105","%Encounter_Cliff2%",1)
-    CreateCreature("BGWOLF",[990.105],0)  // ~Wolf~
+    CreateCreature("WOLF",[990.105],0)  // ~Wolf~
     SetGlobalTimer("4901990105","%Encounter_Cliff2%",2400)
 END
-

--- a/BGSpawn/scripts/FW05000.baf
+++ b/BGSpawn/scripts/FW05000.baf
@@ -397,7 +397,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -434,7 +434,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -473,7 +473,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -512,7 +512,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -553,7 +553,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -602,7 +602,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -649,7 +649,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -689,7 +689,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -729,7 +729,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -775,7 +775,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -863,7 +863,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -899,7 +899,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -944,7 +944,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -989,7 +989,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1036,7 +1036,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1083,7 +1083,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1138,7 +1138,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1184,7 +1184,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1218,7 +1218,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1252,12 +1252,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1297,12 +1297,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1349,12 +1349,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1401,12 +1401,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1889,7 +1889,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #24
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1931,7 +1931,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -1979,7 +1979,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2027,7 +2027,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2090,7 +2090,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2153,7 +2153,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2227,7 +2227,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2291,7 +2291,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2357,7 +2357,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2437,7 +2437,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2528,7 +2528,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2621,7 +2621,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2736,7 +2736,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2820,7 +2820,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -2910,7 +2910,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3023,7 +3023,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3094,7 +3094,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3186,7 +3186,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3232,7 +3232,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3284,7 +3284,7 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3363,12 +3363,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3446,12 +3446,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3559,12 +3559,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
@@ -3686,12 +3686,12 @@ THEN
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3328.1408],0)  // Lesser Basilisk
     SetGlobalTimer("050033281408","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset33281408","%DurlagsTower%",1)

--- a/BGSpawn/scripts/FW05001.baf
+++ b/BGSpawn/scripts/FW05001.baf
@@ -397,7 +397,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -434,7 +434,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -473,7 +473,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -512,7 +512,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -553,7 +553,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -602,7 +602,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -649,7 +649,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -689,7 +689,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -729,7 +729,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -775,7 +775,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -863,7 +863,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -899,7 +899,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -944,7 +944,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -989,7 +989,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1036,7 +1036,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1083,7 +1083,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1138,7 +1138,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1184,7 +1184,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1218,7 +1218,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1252,12 +1252,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1297,12 +1297,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1349,12 +1349,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1401,12 +1401,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1889,7 +1889,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #24
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1931,7 +1931,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -1979,7 +1979,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2027,7 +2027,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2090,7 +2090,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2153,7 +2153,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2227,7 +2227,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2291,7 +2291,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2357,7 +2357,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2437,7 +2437,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2528,7 +2528,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2621,7 +2621,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2736,7 +2736,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2820,7 +2820,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -2910,7 +2910,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3023,7 +3023,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3094,7 +3094,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3186,7 +3186,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3232,7 +3232,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3284,7 +3284,7 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3363,12 +3363,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3446,12 +3446,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3559,12 +3559,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
@@ -3686,12 +3686,12 @@ THEN
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[578.3387],0)  // Lesser Basilisk
     SetGlobalTimer("05005783387","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5783387","%DurlagsTower%",1)

--- a/BGSpawn/scripts/FW05002.baf
+++ b/BGSpawn/scripts/FW05002.baf
@@ -397,7 +397,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -434,7 +434,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -473,7 +473,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -512,7 +512,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -553,7 +553,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -602,7 +602,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -649,7 +649,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -689,7 +689,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -729,7 +729,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -775,7 +775,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -863,7 +863,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -899,7 +899,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -944,7 +944,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -989,7 +989,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1036,7 +1036,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1083,7 +1083,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1138,7 +1138,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1184,7 +1184,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1218,7 +1218,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1252,12 +1252,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1297,12 +1297,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1349,12 +1349,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1401,12 +1401,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1889,7 +1889,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #24
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1931,7 +1931,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -1979,7 +1979,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2027,7 +2027,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2090,7 +2090,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2153,7 +2153,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2227,7 +2227,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2291,7 +2291,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2357,7 +2357,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2437,7 +2437,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2528,7 +2528,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #12
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2621,7 +2621,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2736,7 +2736,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2820,7 +2820,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -2910,7 +2910,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3023,7 +3023,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3094,7 +3094,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3186,7 +3186,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3232,7 +3232,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3284,7 +3284,7 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3363,12 +3363,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3446,12 +3446,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3559,12 +3559,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
@@ -3686,12 +3686,12 @@ THEN
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1891.1761],0)  // Lesser Basilisk
     SetGlobalTimer("050018911761","%DurlagsTower%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset18911761","%DurlagsTower%",1)

--- a/BGSpawn/scripts/FW15006.baf
+++ b/BGSpawn/scripts/FW15006.baf
@@ -4054,7 +4054,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset27673754","%IsleofBalduranN%",1)
-    CreateCreature("BGWOLF",[2767.3754],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[2767.3754],0)  // ~Wolf~
     SetGlobalTimer("150027673754","%IsleofBalduranN%",2400)
 END
 

--- a/BGSpawn/scripts/FW15008.baf
+++ b/BGSpawn/scripts/FW15008.baf
@@ -4054,7 +4054,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset3246607","%IsleofBalduranN%",1)
-    CreateCreature("BGWOLF",[3246.607],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[3246.607],0)  // ~Wolf~
     SetGlobalTimer("15003246607","%IsleofBalduranN%",2400)
 END
 

--- a/BGSpawn/scripts/FW18001.baf
+++ b/BGSpawn/scripts/FW18001.baf
@@ -11819,7 +11819,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset3021292","%CloakwoodMines%",1)
-    CreateCreature("BGWOLF",[3021.292],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[3021.292],0)  // ~Wolf~
     SetGlobalTimer("18003021292","%CloakwoodMines%",2400)
 END
 

--- a/BGSpawn/scripts/FW18002.baf
+++ b/BGSpawn/scripts/FW18002.baf
@@ -11819,7 +11819,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset41251703","%CloakwoodMines%",1)
-    CreateCreature("BGWOLF",[4125.1703],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4125.1703],0)  // ~Wolf~
     SetGlobalTimer("180041251703","%CloakwoodMines%",2400)
 END
 

--- a/BGSpawn/scripts/FW22005.baf
+++ b/BGSpawn/scripts/FW22005.baf
@@ -6352,7 +6352,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset9003217","%CloakwoodLodge%",1)
-    CreateCreature("BGWOLF",[900.3217],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[900.3217],0)  // ~Wolf~
     SetGlobalTimer("22009003217","%CloakwoodLodge%",2400)
 END
 

--- a/BGSpawn/scripts/FW280010.baf
+++ b/BGSpawn/scripts/FW280010.baf
@@ -11818,7 +11818,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset1263894","%CoastWay%",1)
-    CreateCreature("BGWOLF",[1263.894],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[1263.894],0)  // ~Wolf~
     SetGlobalTimer("28001263894","%CoastWay%",2400)
 END
 

--- a/BGSpawn/scripts/FW31000.baf
+++ b/BGSpawn/scripts/FW31000.baf
@@ -6044,7 +6044,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset1168341","%ShipwrecksCoast%",1)
-    CreateCreature("BGWOLF",[1168.341],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[1168.341],0)  // ~Wolf~
     SetGlobalTimer("31001168341","%ShipwrecksCoast%",2400)
 END
 

--- a/BGSpawn/scripts/FW31002.baf
+++ b/BGSpawn/scripts/FW31002.baf
@@ -6042,7 +6042,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset4075462","%ShipwrecksCoast%",1)
-    CreateCreature("BGWOLF",[4075.462],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4075.462],0)  // ~Wolf~
     SetGlobalTimer("31004075462","%ShipwrecksCoast%",2400)
 END
 

--- a/BGSpawn/scripts/FW31003.baf
+++ b/BGSpawn/scripts/FW31003.baf
@@ -6042,7 +6042,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset40541683","%ShipwrecksCoast%",1)
-    CreateCreature("BGWOLF",[4054.1683],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4054.1683],0)  // ~Wolf~
     SetGlobalTimer("310040541683","%ShipwrecksCoast%",2400)
 END
 

--- a/BGSpawn/scripts/FW31004.baf
+++ b/BGSpawn/scripts/FW31004.baf
@@ -6042,7 +6042,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset39833025","%ShipwrecksCoast%",1)
-    CreateCreature("BGWOLF",[3983.3025],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[3983.3025],0)  // ~Wolf~
     SetGlobalTimer("310039833025","%ShipwrecksCoast%",2400)
 END
 

--- a/BGSpawn/scripts/FW31007.baf
+++ b/BGSpawn/scripts/FW31007.baf
@@ -6042,7 +6042,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset8052345","%ShipwrecksCoast%",1)
-    CreateCreature("BGWOLF",[805.2345],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[805.2345],0)  // ~Wolf~
     SetGlobalTimer("31008052345","%ShipwrecksCoast%",2400)
 END
 

--- a/BGSpawn/scripts/FW34002.baf
+++ b/BGSpawn/scripts/FW34002.baf
@@ -6674,7 +6674,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset44202111","%Temple%",1)
-    CreateCreature("BGWOLF",[4420.2111],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4420.2111],0)  // ~Wolf~
     SetGlobalTimer("340044202111","%Temple%",2400)
 END
 

--- a/BGSpawn/scripts/FW35000.baf
+++ b/BGSpawn/scripts/FW35000.baf
@@ -53,7 +53,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -90,7 +90,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -127,7 +127,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -169,7 +169,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -211,7 +211,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -258,7 +258,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -301,7 +301,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -349,7 +349,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -410,7 +410,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -487,7 +487,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -565,7 +565,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -676,7 +676,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -735,7 +735,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -822,7 +822,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -918,7 +918,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1031,7 +1031,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1149,7 +1149,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1266,7 +1266,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1325,7 +1325,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1396,7 +1396,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1477,7 +1477,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1613,7 +1613,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1758,7 +1758,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1925,7 +1925,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1979,7 +1979,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2037,7 +2037,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2140,7 +2140,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2257,7 +2257,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2398,7 +2398,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2555,12 +2555,12 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2625,7 +2625,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2695,7 +2695,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2835,12 +2835,12 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2980,12 +2980,12 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3125,18 +3125,18 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3281,18 +3281,18 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3334,7 +3334,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3379,7 +3379,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3424,7 +3424,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3474,7 +3474,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3524,7 +3524,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3574,7 +3574,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3619,7 +3619,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3664,7 +3664,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3719,7 +3719,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3779,7 +3779,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3839,7 +3839,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3911,7 +3911,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -3971,7 +3971,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4037,7 +4037,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4103,7 +4103,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4195,7 +4195,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4287,7 +4287,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4388,7 +4388,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4471,7 +4471,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4545,7 +4545,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4632,7 +4632,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4735,7 +4735,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4850,7 +4850,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -4973,7 +4973,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5062,7 +5062,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5168,7 +5168,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5286,7 +5286,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5439,7 +5439,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5557,7 +5557,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5712,12 +5712,12 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5796,7 +5796,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -5915,7 +5915,7 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -6047,12 +6047,12 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -6229,12 +6229,12 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -6447,18 +6447,18 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
@@ -6663,25 +6663,25 @@ THEN
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[503.1305],0)  // Lesser Basilisk
     SetGlobalTimer("35005031305","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5031305","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35001.baf
+++ b/BGSpawn/scripts/FW35001.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2626.264],0)  // Lesser Basilisk
     SetGlobalTimer("35002626264","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2626264","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35002.baf
+++ b/BGSpawn/scripts/FW35002.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4065.805],0)  // Lesser Basilisk
     SetGlobalTimer("35004065805","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4065805","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35003.baf
+++ b/BGSpawn/scripts/FW35003.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3970.1822],0)  // Lesser Basilisk
     SetGlobalTimer("350039701822","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset39701822","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35004.baf
+++ b/BGSpawn/scripts/FW35004.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2779.2064],0)  // Lesser Basilisk
     SetGlobalTimer("350027792064","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset27792064","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35005.baf
+++ b/BGSpawn/scripts/FW35005.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1024.1984],0)  // Lesser Basilisk
     SetGlobalTimer("350010241984","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset10241984","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35006.baf
+++ b/BGSpawn/scripts/FW35006.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1161.3182],0)  // Lesser Basilisk
     SetGlobalTimer("350011613182","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset11613182","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW35007.baf
+++ b/BGSpawn/scripts/FW35007.baf
@@ -52,7 +52,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -89,7 +89,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -126,7 +126,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -168,7 +168,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -210,7 +210,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -257,7 +257,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -300,7 +300,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -348,7 +348,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -409,7 +409,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -486,7 +486,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -564,7 +564,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -675,7 +675,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -734,7 +734,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -821,7 +821,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -917,7 +917,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1030,7 +1030,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1148,7 +1148,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1265,7 +1265,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1324,7 +1324,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1395,7 +1395,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1476,7 +1476,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1612,7 +1612,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1757,7 +1757,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1924,7 +1924,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -1978,7 +1978,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2036,7 +2036,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2256,7 +2256,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2397,7 +2397,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2624,7 +2624,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2694,7 +2694,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2834,12 +2834,12 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -2979,12 +2979,12 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3124,18 +3124,18 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3280,18 +3280,18 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
 END
 
@@ -3333,7 +3333,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3378,7 +3378,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3423,7 +3423,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3473,7 +3473,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3523,7 +3523,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3573,7 +3573,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3618,7 +3618,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3663,7 +3663,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3718,7 +3718,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3778,7 +3778,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3838,7 +3838,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3910,7 +3910,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -3970,7 +3970,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4036,7 +4036,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #20
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4102,7 +4102,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4194,7 +4194,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4286,7 +4286,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4387,7 +4387,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4470,7 +4470,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4544,7 +4544,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4631,7 +4631,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4734,7 +4734,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4849,7 +4849,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -4972,7 +4972,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5061,7 +5061,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5167,7 +5167,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5285,7 +5285,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5438,7 +5438,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5556,7 +5556,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5711,12 +5711,12 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5795,7 +5795,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -5914,7 +5914,7 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -6046,12 +6046,12 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -6228,12 +6228,12 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -6446,18 +6446,18 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #11
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
@@ -6662,25 +6662,25 @@ THEN
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4113.2622],0)  // Lesser Basilisk
     SetGlobalTimer("350041132622","%MutaminsGarden%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset41132622","%MutaminsGarden%",1)

--- a/BGSpawn/scripts/FW37002.baf
+++ b/BGSpawn/scripts/FW37002.baf
@@ -6563,7 +6563,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset41531913","%RedCanyons%",1)
-    CreateCreature("BGWOLF",[4153.1913],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4153.1913],0)  // ~Wolf~
     SetGlobalTimer("370041531913","%RedCanyons%",2400)
 END
 

--- a/BGSpawn/scripts/FW37006.baf
+++ b/BGSpawn/scripts/FW37006.baf
@@ -6563,7 +6563,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset10281945","%RedCanyons%",1)
-    CreateCreature("BGWOLF",[1028.1945],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[1028.1945],0)  // ~Wolf~
     SetGlobalTimer("370010281945","%RedCanyons%",2400)
 END
 

--- a/BGSpawn/scripts/FW42002.baf
+++ b/BGSpawn/scripts/FW42002.baf
@@ -7793,7 +7793,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset37021965","%FishermansLake%",1)
-    CreateCreature("BGWOLF",[3702.1965],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[3702.1965],0)  // ~Wolf~
     SetGlobalTimer("420037021965","%FishermansLake%",2400)
 END
 

--- a/BGSpawn/scripts/FW43003.baf
+++ b/BGSpawn/scripts/FW43003.baf
@@ -7138,43 +7138,43 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7268,61 +7268,61 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7414,46 +7414,46 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7523,41 +7523,41 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7651,60 +7651,60 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7813,68 +7813,68 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7987,7 +7987,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -7995,9 +7995,9 @@ THEN
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -8005,50 +8005,50 @@ THEN
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3338.1629],0) // Kobold
@@ -8056,7 +8056,7 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8178,7 +8178,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -8187,18 +8187,18 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -8207,58 +8207,58 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8424,35 +8424,35 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8541,36 +8541,36 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #3
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8680,32 +8680,32 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -8713,7 +8713,7 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8861,7 +8861,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -8869,9 +8869,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -8879,38 +8879,38 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9076,7 +9076,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9084,9 +9084,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9094,38 +9094,38 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9327,15 +9327,15 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9345,9 +9345,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9357,9 +9357,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9369,9 +9369,9 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9381,9 +9381,9 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9391,9 +9391,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9401,9 +9401,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9411,24 +9411,24 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9640,12 +9640,12 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9653,48 +9653,48 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9833,12 +9833,12 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9847,18 +9847,18 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -9866,34 +9866,34 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10072,13 +10072,13 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10088,9 +10088,9 @@ THEN
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3338.1629],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10098,9 +10098,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10109,9 +10109,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10119,9 +10119,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10129,9 +10129,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10139,7 +10139,7 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10299,7 +10299,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10310,9 +10310,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10323,9 +10323,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10333,9 +10333,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10343,9 +10343,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10353,9 +10353,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -10363,9 +10363,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -10374,7 +10374,7 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10601,7 +10601,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10613,9 +10613,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10627,9 +10627,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10638,9 +10638,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10649,9 +10649,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10660,9 +10660,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10671,9 +10671,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -10683,7 +10683,7 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10912,7 +10912,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10925,9 +10925,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10940,9 +10940,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10954,9 +10954,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -10968,9 +10968,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -10978,9 +10978,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
@@ -10988,9 +10988,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11001,9 +11001,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11013,9 +11013,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11027,9 +11027,9 @@ THEN
     CreateCreature("KOBLDGD",[3338.1629],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11042,7 +11042,7 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11314,7 +11314,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11322,50 +11322,50 @@ THEN
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11477,7 +11477,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11487,9 +11487,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11499,52 +11499,52 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11680,7 +11680,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -11692,9 +11692,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -11706,9 +11706,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11717,9 +11717,9 @@ THEN
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11728,9 +11728,9 @@ THEN
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11739,9 +11739,9 @@ THEN
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11750,9 +11750,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11761,7 +11761,7 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11862,7 +11862,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11873,9 +11873,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11886,9 +11886,9 @@ THEN
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11899,9 +11899,9 @@ THEN
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11912,9 +11912,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11925,9 +11925,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11938,9 +11938,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11951,9 +11951,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11964,9 +11964,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11977,9 +11977,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -11990,7 +11990,7 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12161,7 +12161,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12174,9 +12174,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12188,9 +12188,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12202,9 +12202,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12216,9 +12216,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12230,9 +12230,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12244,9 +12244,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12258,9 +12258,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12272,9 +12272,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12286,9 +12286,9 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3338.1629],0) // Kobold Chieftain
@@ -12300,7 +12300,7 @@ THEN
     CreateCreature("KOBSHA01",[3338.1629],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12515,7 +12515,7 @@ IF
   Global("RandomSet33381629_3","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12529,9 +12529,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12545,9 +12545,9 @@ THEN
     CreateCreature("KOBCOMM",[3338.1629],0) // Kobold Commando
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3338.1629],0) // Kobold Kamikaze
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12564,9 +12564,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12583,9 +12583,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12601,9 +12601,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12619,9 +12619,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12637,9 +12637,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12655,9 +12655,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12673,9 +12673,9 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33381629","AR6600",1)
+    SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3338.1629],0) // Kobold Captain
@@ -12691,7 +12691,7 @@ THEN
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3338.1629],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3338.1629],0) // Kobold Scribe
-    SetGlobalTimer("430033381629","AR6600",2400)
+    SetGlobalTimer("430033381629","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33381629","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033381629","%NorthNashkelRoad%",EIGHT_HOURS)

--- a/BGSpawn/scripts/FW43004.baf
+++ b/BGSpawn/scripts/FW43004.baf
@@ -7138,43 +7138,43 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7268,61 +7268,61 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7414,46 +7414,46 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7523,41 +7523,41 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7651,60 +7651,60 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7813,68 +7813,68 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7987,7 +7987,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -7995,9 +7995,9 @@ THEN
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -8005,50 +8005,50 @@ THEN
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[3379.2980],0) // Kobold
@@ -8056,7 +8056,7 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8178,7 +8178,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -8187,18 +8187,18 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -8207,58 +8207,58 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8424,35 +8424,35 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8541,36 +8541,36 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #3
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8680,32 +8680,32 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -8713,7 +8713,7 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8861,7 +8861,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -8869,9 +8869,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -8879,38 +8879,38 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9076,7 +9076,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9084,9 +9084,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9094,38 +9094,38 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9327,15 +9327,15 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9345,9 +9345,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9357,9 +9357,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9369,9 +9369,9 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9381,9 +9381,9 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9391,9 +9391,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9401,9 +9401,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9411,24 +9411,24 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9640,12 +9640,12 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9653,48 +9653,48 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9833,12 +9833,12 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9847,18 +9847,18 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -9866,34 +9866,34 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10072,13 +10072,13 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10088,9 +10088,9 @@ THEN
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[3379.2980],0) // Kobold Archer
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10098,9 +10098,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10109,9 +10109,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10119,9 +10119,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10129,9 +10129,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10139,7 +10139,7 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10299,7 +10299,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10310,9 +10310,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10323,9 +10323,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10333,9 +10333,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10343,9 +10343,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10353,9 +10353,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -10363,9 +10363,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -10374,7 +10374,7 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10601,7 +10601,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10613,9 +10613,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10627,9 +10627,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10638,9 +10638,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10649,9 +10649,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10660,9 +10660,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10671,9 +10671,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -10683,7 +10683,7 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10912,7 +10912,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10925,9 +10925,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10940,9 +10940,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10954,9 +10954,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -10968,9 +10968,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -10978,9 +10978,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
@@ -10988,9 +10988,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11001,9 +11001,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11013,9 +11013,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11027,9 +11027,9 @@ THEN
     CreateCreature("KOBLDGD",[3379.2980],0) // Kobold Guard
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11042,7 +11042,7 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11314,7 +11314,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11322,50 +11322,50 @@ THEN
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11477,7 +11477,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11487,9 +11487,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11499,52 +11499,52 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11680,7 +11680,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -11692,9 +11692,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -11706,9 +11706,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11717,9 +11717,9 @@ THEN
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11728,9 +11728,9 @@ THEN
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11739,9 +11739,9 @@ THEN
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11750,9 +11750,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11761,7 +11761,7 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11862,7 +11862,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11873,9 +11873,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11886,9 +11886,9 @@ THEN
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11899,9 +11899,9 @@ THEN
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11912,9 +11912,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11925,9 +11925,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11938,9 +11938,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11951,9 +11951,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11964,9 +11964,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11977,9 +11977,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -11990,7 +11990,7 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12161,7 +12161,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12174,9 +12174,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12188,9 +12188,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12202,9 +12202,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12216,9 +12216,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12230,9 +12230,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12244,9 +12244,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12258,9 +12258,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12272,9 +12272,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12286,9 +12286,9 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[3379.2980],0) // Kobold Chieftain
@@ -12300,7 +12300,7 @@ THEN
     CreateCreature("KOBSHA01",[3379.2980],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12515,7 +12515,7 @@ IF
   Global("RandomSet33792980_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12529,9 +12529,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12545,9 +12545,9 @@ THEN
     CreateCreature("KOBCOMM",[3379.2980],0) // Kobold Commando
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[3379.2980],0) // Kobold Kamikaze
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12564,9 +12564,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12583,9 +12583,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12601,9 +12601,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12619,9 +12619,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12637,9 +12637,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12655,9 +12655,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12673,9 +12673,9 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset33792980","AR6600",1)
+    SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
     CreateCreature("KOBCAP01",[3379.2980],0) // Kobold Captain
@@ -12691,7 +12691,7 @@ THEN
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[3379.2980],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[3379.2980],0) // Kobold Scribe
-    SetGlobalTimer("430033792980","AR6600",2400)
+    SetGlobalTimer("430033792980","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset33792980","%NorthNashkelRoad%",1)
     SetGlobalTimer("430033792980","%NorthNashkelRoad%",EIGHT_HOURS)

--- a/BGSpawn/scripts/FW43005.baf
+++ b/BGSpawn/scripts/FW43005.baf
@@ -7138,43 +7138,43 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7268,61 +7268,61 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7414,46 +7414,46 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7523,41 +7523,41 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7651,60 +7651,60 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7813,68 +7813,68 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7987,7 +7987,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -7995,9 +7995,9 @@ THEN
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -8005,50 +8005,50 @@ THEN
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[2637.3178],0) // Kobold
@@ -8056,7 +8056,7 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8178,7 +8178,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -8187,18 +8187,18 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -8207,58 +8207,58 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8424,35 +8424,35 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8541,36 +8541,36 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #3
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8680,32 +8680,32 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -8713,7 +8713,7 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8861,7 +8861,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -8869,9 +8869,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -8879,38 +8879,38 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9076,7 +9076,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9084,9 +9084,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9094,38 +9094,38 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9327,15 +9327,15 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9345,9 +9345,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9357,9 +9357,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9369,9 +9369,9 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9381,9 +9381,9 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9391,9 +9391,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9401,9 +9401,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9411,24 +9411,24 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9640,12 +9640,12 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9653,48 +9653,48 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9833,12 +9833,12 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9847,18 +9847,18 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -9866,34 +9866,34 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10072,13 +10072,13 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10088,9 +10088,9 @@ THEN
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[2637.3178],0) // Kobold Archer
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10098,9 +10098,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10109,9 +10109,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10119,9 +10119,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10129,9 +10129,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10139,7 +10139,7 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10299,7 +10299,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10310,9 +10310,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10323,9 +10323,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10333,9 +10333,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10343,9 +10343,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10353,9 +10353,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -10363,9 +10363,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -10374,7 +10374,7 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10601,7 +10601,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10613,9 +10613,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10627,9 +10627,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10638,9 +10638,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10649,9 +10649,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10660,9 +10660,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10671,9 +10671,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -10683,7 +10683,7 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10912,7 +10912,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10925,9 +10925,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10940,9 +10940,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10954,9 +10954,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -10968,9 +10968,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -10978,9 +10978,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
@@ -10988,9 +10988,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11001,9 +11001,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11013,9 +11013,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11027,9 +11027,9 @@ THEN
     CreateCreature("KOBLDGD",[2637.3178],0) // Kobold Guard
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11042,7 +11042,7 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11314,7 +11314,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11322,50 +11322,50 @@ THEN
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11477,7 +11477,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11487,9 +11487,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11499,52 +11499,52 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11680,7 +11680,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -11692,9 +11692,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -11706,9 +11706,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11717,9 +11717,9 @@ THEN
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11728,9 +11728,9 @@ THEN
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11739,9 +11739,9 @@ THEN
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11750,9 +11750,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11761,7 +11761,7 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11862,7 +11862,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11873,9 +11873,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11886,9 +11886,9 @@ THEN
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11899,9 +11899,9 @@ THEN
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11912,9 +11912,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11925,9 +11925,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11938,9 +11938,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11951,9 +11951,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11964,9 +11964,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11977,9 +11977,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -11990,7 +11990,7 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12161,7 +12161,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12174,9 +12174,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12188,9 +12188,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12202,9 +12202,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12216,9 +12216,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12230,9 +12230,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12244,9 +12244,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12258,9 +12258,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12272,9 +12272,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12286,9 +12286,9 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[2637.3178],0) // Kobold Chieftain
@@ -12300,7 +12300,7 @@ THEN
     CreateCreature("KOBSHA01",[2637.3178],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12515,7 +12515,7 @@ IF
   Global("RandomSet26373178_2","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12529,9 +12529,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12545,9 +12545,9 @@ THEN
     CreateCreature("KOBCOMM",[2637.3178],0) // Kobold Commando
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[2637.3178],0) // Kobold Kamikaze
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12564,9 +12564,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12583,9 +12583,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12601,9 +12601,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12619,9 +12619,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12637,9 +12637,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12655,9 +12655,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12673,9 +12673,9 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset26373178","AR6600",1)
+    SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
     CreateCreature("KOBCAP01",[2637.3178],0) // Kobold Captain
@@ -12691,7 +12691,7 @@ THEN
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[2637.3178],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[2637.3178],0) // Kobold Scribe
-    SetGlobalTimer("430026373178","AR6600",2400)
+    SetGlobalTimer("430026373178","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset26373178","%NorthNashkelRoad%",1)
     SetGlobalTimer("430026373178","%NorthNashkelRoad%",EIGHT_HOURS)

--- a/BGSpawn/scripts/FW43006.baf
+++ b/BGSpawn/scripts/FW43006.baf
@@ -7138,43 +7138,43 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7268,61 +7268,61 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7414,46 +7414,46 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7523,41 +7523,41 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7651,60 +7651,60 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7813,68 +7813,68 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -7987,7 +7987,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -7995,9 +7995,9 @@ THEN
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -8005,50 +8005,50 @@ THEN
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBOLD_B",[955.2836],0) // Kobold
@@ -8056,7 +8056,7 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8178,7 +8178,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -8187,18 +8187,18 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -8207,58 +8207,58 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8424,35 +8424,35 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8541,36 +8541,36 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #3
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8680,32 +8680,32 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -8713,7 +8713,7 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -8861,7 +8861,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -8869,9 +8869,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -8879,38 +8879,38 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9076,7 +9076,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9084,9 +9084,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9094,38 +9094,38 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #3
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9327,15 +9327,15 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9345,9 +9345,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9357,9 +9357,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9369,9 +9369,9 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9381,9 +9381,9 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9391,9 +9391,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9401,9 +9401,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9411,24 +9411,24 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9640,12 +9640,12 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9653,48 +9653,48 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -9833,12 +9833,12 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9847,18 +9847,18 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -9866,34 +9866,34 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10072,13 +10072,13 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10088,9 +10088,9 @@ THEN
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBOLA_D",[955.2836],0) // Kobold Archer
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10098,9 +10098,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10109,9 +10109,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10119,9 +10119,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10129,9 +10129,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10139,7 +10139,7 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10299,7 +10299,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10310,9 +10310,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10323,9 +10323,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10333,9 +10333,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10343,9 +10343,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10353,9 +10353,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -10363,9 +10363,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -10374,7 +10374,7 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10601,7 +10601,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10613,9 +10613,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10627,9 +10627,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10638,9 +10638,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10649,9 +10649,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10660,9 +10660,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10671,9 +10671,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -10683,7 +10683,7 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -10912,7 +10912,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10925,9 +10925,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10940,9 +10940,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10954,9 +10954,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -10968,9 +10968,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -10978,9 +10978,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
@@ -10988,9 +10988,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11001,9 +11001,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11013,9 +11013,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11027,9 +11027,9 @@ THEN
     CreateCreature("KOBLDGD",[955.2836],0) // Kobold Guard
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11042,7 +11042,7 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11314,7 +11314,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11322,50 +11322,50 @@ THEN
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11477,7 +11477,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11487,9 +11487,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11499,52 +11499,52 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11680,7 +11680,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -11692,9 +11692,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -11706,9 +11706,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11717,9 +11717,9 @@ THEN
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11728,9 +11728,9 @@ THEN
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11739,9 +11739,9 @@ THEN
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11750,9 +11750,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #2
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11761,7 +11761,7 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -11862,7 +11862,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11873,9 +11873,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11886,9 +11886,9 @@ THEN
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11899,9 +11899,9 @@ THEN
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11912,9 +11912,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11925,9 +11925,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11938,9 +11938,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11951,9 +11951,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11964,9 +11964,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11977,9 +11977,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -11990,7 +11990,7 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12161,7 +12161,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12174,9 +12174,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12188,9 +12188,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12202,9 +12202,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12216,9 +12216,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12230,9 +12230,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12244,9 +12244,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12258,9 +12258,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12272,9 +12272,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12286,9 +12286,9 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("SKOBCHIE",[955.2836],0) // Kobold Chieftain
@@ -12300,7 +12300,7 @@ THEN
     CreateCreature("KOBSHA01",[955.2836],0) // Kobold Shaman
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)
@@ -12515,7 +12515,7 @@ IF
   Global("RandomSet9552836_1","%NorthNashkelRoad%",1)
 THEN
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12529,9 +12529,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12545,9 +12545,9 @@ THEN
     CreateCreature("KOBCOMM",[955.2836],0) // Kobold Commando
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
     CreateCreature("KOBKAM01",[955.2836],0) // Kobold Kamikaze
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12564,9 +12564,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12583,9 +12583,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12601,9 +12601,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12619,9 +12619,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12637,9 +12637,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12655,9 +12655,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12673,9 +12673,9 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #1
-    SetGlobal("SpawnReset9552836","AR6600",1)
+    SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
     CreateCreature("KOBCAP01",[955.2836],0) // Kobold Captain
@@ -12691,7 +12691,7 @@ THEN
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBWIT01",[955.2836],0) // Kobold Witch Doctor
     CreateCreature("KOBSCR01",[955.2836],0) // Kobold Scribe
-    SetGlobalTimer("43009552836","AR6600",2400)
+    SetGlobalTimer("43009552836","%NorthNashkelRoad%",2400)
   RESPONSE #10
     SetGlobal("SpawnReset9552836","%NorthNashkelRoad%",1)
     SetGlobalTimer("43009552836","%NorthNashkelRoad%",EIGHT_HOURS)

--- a/BGSpawn/scripts/FW44002.baf
+++ b/BGSpawn/scripts/FW44002.baf
@@ -8582,7 +8582,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset4023594","%LonelyPeaks%",1)
-    CreateCreature("BGWOLF",[4023.594],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4023.594],0)  // ~Wolf~
     SetGlobalTimer("44004023594","%LonelyPeaks%",2400)
 END
 

--- a/BGSpawn/scripts/FW44003.baf
+++ b/BGSpawn/scripts/FW44003.baf
@@ -8582,7 +8582,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset40111957","%LonelyPeaks%",1)
-    CreateCreature("BGWOLF",[4011.1957],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4011.1957],0)  // ~Wolf~
     SetGlobalTimer("440040111957","%LonelyPeaks%",2400)
 END
 

--- a/BGSpawn/scripts/FW44007.baf
+++ b/BGSpawn/scripts/FW44007.baf
@@ -8583,7 +8583,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset23883324","%LonelyPeaks%",1)
-    CreateCreature("BGWOLF",[2388.3324],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[2388.3324],0)  // ~Wolf~
     SetGlobalTimer("440023883324","%LonelyPeaks%",2400)
 END
 

--- a/BGSpawn/scripts/FW45000.baf
+++ b/BGSpawn/scripts/FW45000.baf
@@ -1376,7 +1376,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1470,7 +1470,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1560,7 +1560,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1661,7 +1661,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1780,7 +1780,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1940,7 +1940,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2035,7 +2035,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2139,7 +2139,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2218,7 +2218,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2326,7 +2326,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2441,7 +2441,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2554,12 +2554,12 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2622,7 +2622,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -2706,7 +2706,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -2778,12 +2778,12 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -2856,18 +2856,18 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -2984,18 +2984,18 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -3097,14 +3097,14 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -5723,7 +5723,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5868,7 +5868,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6031,7 +6031,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6222,7 +6222,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6420,7 +6420,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6732,7 +6732,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6836,7 +6836,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -6977,7 +6977,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -7157,7 +7157,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -7401,7 +7401,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -7671,7 +7671,7 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
@@ -8011,12 +8011,12 @@ THEN
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1508.262],0)  // Lesser Basilisk
     SetGlobalTimer("45001508262","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset1508262","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45001.baf
+++ b/BGSpawn/scripts/FW45001.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3216.227],0)  // Lesser Basilisk
     SetGlobalTimer("45003216227","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset3216227","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45002.baf
+++ b/BGSpawn/scripts/FW45002.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4082.230],0)  // Lesser Basilisk
     SetGlobalTimer("45004082230","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset4082230","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45003.baf
+++ b/BGSpawn/scripts/FW45003.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[2361.832],0)  // Lesser Basilisk
     SetGlobalTimer("45002361832","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset2361832","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45004.baf
+++ b/BGSpawn/scripts/FW45004.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[4561.2066],0)  // Lesser Basilisk
     SetGlobalTimer("450045612066","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset45612066","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45005.baf
+++ b/BGSpawn/scripts/FW45005.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[3776.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450037762432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset37762432","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45006.baf
+++ b/BGSpawn/scripts/FW45006.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1488.2336],0)  // Lesser Basilisk
     SetGlobalTimer("450014882336","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset14882336","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45007.baf
+++ b/BGSpawn/scripts/FW45007.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[1280.2432],0)  // Lesser Basilisk
     SetGlobalTimer("450012802432","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset12802432","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW45008.baf
+++ b/BGSpawn/scripts/FW45008.baf
@@ -1374,7 +1374,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1468,7 +1468,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1558,7 +1558,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1659,7 +1659,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1778,7 +1778,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -1938,7 +1938,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2033,7 +2033,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2137,7 +2137,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2216,7 +2216,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2324,7 +2324,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2439,7 +2439,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2552,12 +2552,12 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -2620,7 +2620,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -2704,7 +2704,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -2776,12 +2776,12 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -2854,18 +2854,18 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #10
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -2982,18 +2982,18 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #3
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #7
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -3095,14 +3095,14 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -5721,7 +5721,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -5866,7 +5866,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6029,7 +6029,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6220,7 +6220,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6418,7 +6418,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6730,7 +6730,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
 END
 
@@ -6834,7 +6834,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -6975,7 +6975,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -7155,7 +7155,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #5
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -7399,7 +7399,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -7669,7 +7669,7 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #4
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
@@ -8009,12 +8009,12 @@ THEN
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #2
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
-    CreateCreature("BGBASILL",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
+    CreateCreature("%Basilisk%",[565.2486],0)  // Lesser Basilisk
     SetGlobalTimer("45005652486","%FirewineBridge%",EIGHT_HOURS)
   RESPONSE #6
     SetGlobal("SpawnReset5652486","%FirewineBridge%",1)

--- a/BGSpawn/scripts/FW47005.baf
+++ b/BGSpawn/scripts/FW47005.baf
@@ -4793,7 +4793,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset23853268","%XvartVillage%",1)
-    CreateCreature("BGWOLF",[2385.3268],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[2385.3268],0)  // ~Wolf~
     SetGlobalTimer("470023853268","%XvartVillage%",2400)
 END
 

--- a/BGSpawn/scripts/FW52003.baf
+++ b/BGSpawn/scripts/FW52003.baf
@@ -14337,7 +14337,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset44161728","%DryadFalls%",1)
-    CreateCreature("BGWOLF",[4416.1728],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[4416.1728],0)  // ~Wolf~
     SetGlobalTimer("520044161728","%DryadFalls%",2400)
 END
 

--- a/BGSpawn/scripts/FW52006.baf
+++ b/BGSpawn/scripts/FW52006.baf
@@ -14337,7 +14337,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset8812064","%DryadFalls%",1)
-    CreateCreature("BGWOLF",[881.2064],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[881.2064],0)  // ~Wolf~
     SetGlobalTimer("52008812064","%DryadFalls%",2400)
 END
 

--- a/BGSpawn/scripts/FW54004.baf
+++ b/BGSpawn/scripts/FW54004.baf
@@ -8985,7 +8985,7 @@ IF
 THEN
   RESPONSE #100
     SetGlobal("SpawnReset27552102","%NashkelMines%",1)
-    CreateCreature("BGWOLF",[2755.2102],0)  // ~Wolf~
+    CreateCreature("%Wolf%",[2755.2102],0)  // ~Wolf~
     SetGlobalTimer("540027552102","%NashkelMines%",2400)
 END
 


### PR DESCRIPTION
- Feature: Expose the disabling vanilla spawn points to an INI setting.
- Fix: Substitute the remaining few BGT area names.
- Fix: Don't use BGT creature names where EET and BGT names differ.
- Fix: Random Encounter component no longer breaks Dorn's fixed encounter.